### PR TITLE
Add MQTT authentication and customizable topic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # see hooks/build and hooks/.config
 ARG BASE_IMAGE_PREFIX
-FROM ${BASE_IMAGE_PREFIX}python:3-alpine
+FROM ${BASE_IMAGE_PREFIX}python:3.7-alpine
 
 # see hooks/post_checkout
-ARG ARCH
-COPY qemu-${ARCH}-static /usr/bin
+#ARG ARCH
+#COPY qemu-${ARCH}-static /usr/bin
 
 COPY ./requirements.txt /app/requirements.txt
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # see hooks/build and hooks/.config
 ARG BASE_IMAGE_PREFIX
-FROM ${BASE_IMAGE_PREFIX}python:3.7-alpine
+FROM ${BASE_IMAGE_PREFIX}python:3.11-alpine
 
 # see hooks/post_checkout
 #ARG ARCH

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ variable | description | default value
 SUNSTICKPORT     | path to the USB stick        | /dev/ttyUSB0
 MQTTSERVER       | IP of the MQTT brocker       | 127.0.0.1
 MQTTSERVERPORT   | port of the MQTT brocker     | 1883
+MQTTSERVERUSER   | user for MQTT authentication | -
+MQTTSERVERPASS   | password for MQTT authentication | -
+MQTTSERVERTOPIC  | MQTT topic the data is published to | SMI
 POLL             | duration to poll in seconds | 120
 SMI_LIST         | comma spearated list of last 4 digits of the inverter | 1234,2345
 DEBUG            | set debug output            | False

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ SMI/<last 4 digits of inverter serial>/  | TemperatureDCDC | temperature of the 
 
 To setup install all dependencies: `pip3 install -r requirements.txt` 
 
-and then run it with  `python3.7 ./SMI260MQTTGateway.py`
+and then run it with  `python3 ./SMI260MQTTGateway.py`
 
 ## Settings
 You can configure the gateway ether by editing SMI260MQTTGateway.py with your settings (settings are in the lower part of the file) or you can set environment variables:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pyserial_asyncio==0.4
-py_flags==1.1.2
-pycrypto==2.6.1
-paho_mqtt==1.5.0
-pyserial==3.4
+pyserial_asyncio==0.6
+py_flags==1.1.4
+pycryptodome==3.21.0
+paho_mqtt==2.1.0
+pyserial==3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ py_flags==1.1.4
 pycryptodome==3.21.0
 paho_mqtt==2.1.0
 pyserial==3.5
+retry==0.9.2

--- a/src/SMI260MQTTGateway.py
+++ b/src/SMI260MQTTGateway.py
@@ -210,9 +210,12 @@ class Communication(asyncio.Protocol):
 
 async def mqtt_task(async_state):
     mqtt_server = os.getenv('MQTTSERVER', '127.0.0.1')
-    mqtt_port = os.getenv('MQTTSERVERPORT', 1883)
+    mqtt_port = int(os.getenv('MQTTSERVERPORT', 1883))
+    mqtt_user = os.getenv('MQTTSERVERUSER', '')
+    mqtt_pass = os.getenv('MQTTSERVERPASS', None)
     print('MQTT Connecting to ' + mqtt_server + ':' + str(mqtt_port))
     mqtt_client.user_data_set(async_state)
+    mqtt_client.username_pw_set(mqtt_user, mqtt_pass)
     mqtt_client.connected_flag=False
     mqtt_client.on_connect = on_connect
     mqtt_client.on_message = on_message
@@ -224,8 +227,9 @@ async def mqtt_task(async_state):
 
 
 def main():
-    global smi_list, debug
+    global mqtt_common_topic, smi_list, debug
 
+    mqtt_common_topic = os.getenv('MQTTSERVERTOPIC', 'SMI')
     serial_port = os.getenv('SUNSTICKPORT', '/dev/ttyUSB0')
 
     poll_every = int(os.getenv('POLL', 120))

--- a/src/SMI260MQTTGateway.py
+++ b/src/SMI260MQTTGateway.py
@@ -35,7 +35,6 @@ def on_connect(client, userdata, flags, rc):
 
     if rc == 0:
         print("Successfully connected to MQTT")
-        mqtt_client.connected_flag=True
 
         for device in smi_list:
             userdata.device_list[device] = {"Energy": None, "Power": None, "MaxPower": None, "PowerOn": None}
@@ -46,7 +45,6 @@ def on_connect(client, userdata, flags, rc):
 
 def on_disconnect(client, userdata, rc):
     print("disconnecting reason  "  +str(rc))
-    mqtt_client.connected_flag=True
 
 
 def on_message(client, userdata, msg):
@@ -216,7 +214,6 @@ async def mqtt_task(async_state):
     print('MQTT Connecting to ' + mqtt_server + ':' + str(mqtt_port))
     mqtt_client.user_data_set(async_state)
     mqtt_client.username_pw_set(mqtt_user, mqtt_pass)
-    mqtt_client.connected_flag=False
     mqtt_client.on_connect = on_connect
     mqtt_client.on_message = on_message
     mqtt_client.on_disconnect = on_disconnect


### PR DESCRIPTION
Hi Stefan,

in my case a remote MQTT server is used, which needs authentication. So i have added environment variables to set authentication and topic. If not set, the client behaves just like without the patch. Tested and running stable for almost two months now.

Best regards,
Malte